### PR TITLE
add BMTrain in useful repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Abstract: The increasing scale of model size and continuous improvement of perfo
 + Fairscale: https://github.com/facebookresearch/fairscale
 + Colossal-AI: https://github.com/hpcaitech/ColossalAI
 + OneFlow: https://github.com/Oneflow-Inc/oneflow
++ BMTrain: https://github.com/OpenBMB/BMTrain
 
 ## BM Background
 


### PR DESCRIPTION
Hi,
The OpenBMB community has released [BMTrain](https://github.com/OpenBMB/BMTrain) for distributed training of big models. I add the repo to the `Useful Repositories`. Please check it :)